### PR TITLE
Clean up redundant entries in gitignore

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -259,9 +259,6 @@ cwallet.sso.lck# JEnv local Java version configuration file
 # CMake
 cmake-build-*/
 
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
-
 # File-based project format
 *.iws
 
@@ -274,9 +271,6 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
-# Cursive Clojure plugin
-.idea/replstate.xml
-
 # Crashlytics plugin (for Android Studio and IntelliJ)
 com_crashlytics_export_strings.xml
 crashlytics.properties
@@ -284,7 +278,6 @@ crashlytics-build.properties
 fabric.properties
 
 # Editor-based Rest Client
-.idea/httpRequests
 nbproject/private/
 build/
 nbbuild/


### PR DESCRIPTION
This is an extension of #3. Sorry, I didn't notice there were a few separate idea entries elsewhere. These are redundant since `.idea` captures them already.