### PR TITLE
ignore nested metals.sbt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ src_managed/
 project/plugins/project/
 *.class
 *.log
-project/metals.sbt
+metals.sbt
 .metals/
 .bloop/


### PR DESCRIPTION
`metals.sbt` can be on many levels of `project/project/...` structure. We need to ignore them all. 